### PR TITLE
fix for chat error if user has no nickname 

### DIFF
--- a/chat/chatlib/discord_handling.py
+++ b/chat/chatlib/discord_handling.py
@@ -72,7 +72,7 @@ async def extract_chat_history_and_format(
         str(user.id): {
             "username": user.name,
             "author": clean_username(user.name),
-            "nickname": user.nick,
+            "nickname": user.nick  if isinstance(user, discord.Member) else user.name,
             "real name": find_user(guild.name, user, whois_dict),
         }
         for user in users_involved


### PR DESCRIPTION
#1394 [2024-07-31 16:59:58] ERROR [discord.client] Ignoring exception in on_message.

Traceback (most recent call last):
File "{HOME}/redenv/lib/python3.11/site-packages/discord/client.py", line 449, in _run_event await coro(*args, **kwargs)
File "{HOME}/.local/share/Red-DiscordBot/data/jarvis/cogs/CogManager/cogs/chat/chat.py", line 121, in contextual_chat_handler (_, formatted_query, user_names) = await discord_handling.extract_chat_history_and_format( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "{HOME}/.local/share/Red-DiscordBot/data/jarvis/cogs/CogManager/cogs/chat/chatlib/discord_handling.py", line 71, in extract_chat_history_and_format users = {
^
File "{HOME}/.local/share/Red-DiscordBot/data/jarvis/cogs/CogManager/cogs/chat/chatlib/discord_handling.py", line 75, in <dictcomp> "nickname": user.nick,
^^^^^^^^^
AttributeError: 'User' object has no attribute 'nick'